### PR TITLE
Fix TypeScript build errors for CloudFlare deployment

### DIFF
--- a/src/test/vitest.d.ts
+++ b/src/test/vitest.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+/// <reference types="@testing-library/jest-dom" />
+
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers'
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
+  interface AsymmetricMatchersContaining extends jest.Matchers<void, any>, TestingLibraryMatchers<any, void> {}
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -38,5 +38,9 @@
   },
   "include": [
     "src"
+  ],
+  "types": [
+    "vitest/globals",
+    "@testing-library/jest-dom"
   ]
 }


### PR DESCRIPTION
## Summary
- Add vitest.d.ts to declare Jest DOM matcher types for Vitest testing framework
- Configure tsconfig.app.json to include testing library types in TypeScript compilation
- Resolves Property 'toBeInTheDocument' does not exist TypeScript errors during CloudFlare Pages build

## Background
CloudFlare Pages deployment was failing with TypeScript errors because Jest DOM matchers like toBeInTheDocument and toHaveAttribute weren't recognized during the build process.

## Changes Made
1. Created src/test/vitest.d.ts: Declares proper TypeScript interfaces for Jest DOM matchers in Vitest environment
2. Updated tsconfig.app.json: Added explicit type references for vitest/globals and @testing-library/jest-dom

## Test Plan
- [x] Local production build succeeds: pnpm run build:prod
- [x] TypeScript compilation passes without errors
- [x] All Jest DOM matchers properly typed in test files
- [ ] CloudFlare Pages deployment succeeds (pending merge)

Generated with Claude Code